### PR TITLE
Fix AppImage not included in release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,7 @@ jobs:
           chmod +x AppDir/AppRun
 
           appimagetool AppDir
-          mv Mostaqem*.AppImage build/linux/x64/release/mostaqem-linux.AppImage
+          mv Mostaqem*.AppImage mostaqem-linux-x86_64.AppImage
 
       - name: Build RPM Package
         run: |


### PR DESCRIPTION
Renamed the AppImage to match other artifacts and placed it in the root directory so it gets picked up by the release step.